### PR TITLE
Fix the test so it works with 'colcon test'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,4 +60,12 @@ install(
   DESTINATION share/${PROJECT_NAME}/launch_test
 )
 
+if(BUILD_TESTING)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  add_launch_test(
+    "test/test_translational_smoothing.py"
+    TIMEOUT 30
+  )
+endif()
+
 ament_package()

--- a/package.xml
+++ b/package.xml
@@ -31,7 +31,7 @@
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-matplotlib</test_depend>
   <test_depend>ros2test</test_depend>
-  
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/test/test_translational_smoothing.py
+++ b/test/test_translational_smoothing.py
@@ -14,6 +14,8 @@ import os
 import time
 import unittest
 
+import matplotlib
+matplotlib.use('Agg')  # Force matplotlib to not use an X-Windows backend
 import matplotlib.pyplot as plt
 
 import launch

--- a/test/test_translational_smoothing.py
+++ b/test/test_translational_smoothing.py
@@ -157,6 +157,10 @@ class TestCommandProfile(unittest.TestCase):
             while rclpy.ok() and not done:
                 rclpy.spin_once(self.node, timeout_sec=0.1)
                 try:
+                    # this works by virtue of having been printed dt seconds
+                    # (0.1s) after the last publication, which is sufficient
+                    # time for final subscription callbacks here to be
+                    # processed
                     assertInStdout(proc_output, 'PROFILE_SENT', commands)
                     done = True
                 except launch_testing.util.proc_lookup.NoMatchingProcessException:

--- a/test/test_translational_smoothing.py
+++ b/test/test_translational_smoothing.py
@@ -14,6 +14,8 @@ import os
 import time
 import unittest
 
+# choose a backend that lets it construct plots off the main thread
+#  https://stackoverflow.com/questions/49921721/runtimeerror-main-thread-is-not-in-main-loop-with-matplotlib-and-flask
 import matplotlib
 matplotlib.use('Agg')  # Force matplotlib to not use an X-Windows backend
 import matplotlib.pyplot as plt

--- a/test/test_translational_smoothing.py
+++ b/test/test_translational_smoothing.py
@@ -14,6 +14,8 @@ import os
 import time
 import unittest
 
+import matplotlib.pyplot as plt
+
 import launch
 import launch_ros
 import launch_ros.actions
@@ -151,7 +153,7 @@ class TestCommandProfile(unittest.TestCase):
             while rclpy.ok() and not done:
                 rclpy.spin_once(self.node, timeout_sec=0.1)
                 try:
-                    assertInStdout(proc_output, "PROFILE_SENT", commands)
+                    assertInStdout(proc_output, 'PROFILE_SENT', commands)
                     done = True
                 except launch_testing.util.proc_lookup.NoMatchingProcessException:
                     pass
@@ -161,5 +163,13 @@ class TestCommandProfile(unittest.TestCase):
             self.assertAlmostEqual(0.5, max(input_velocities))
             self.assertTrue(0.5 > max(smoothed_velocities))
             self.assertTrue(0.4 < max(smoothed_velocities))
+            # plot a graph for easy viz
+            plt.plot(input_timestamps, input_velocities, label='input')
+            plt.plot(smoothed_timestamps, smoothed_velocities, label='smooth')
+            plt.xlabel('time')
+            plt.ylabel('velocity')
+            plt.title('Raw Input vs Smoothed Velocities')
+            plt.legend()
+            plt.savefig('profiles.png')
             self.node.destroy_subscription(input_subscriber)
             self.node.destroy_subscription(smoothed_subscriber)

--- a/test/test_translational_smoothing.py
+++ b/test/test_translational_smoothing.py
@@ -10,21 +10,10 @@
 # Imports
 ##############################################################################
 
-import matplotlib
-# choose a backend that lets it construct plots off the main thread
-#  https://stackoverflow.com/questions/49921721/runtimeerror-main-thread-is-not-in-main-loop-with-matplotlib-and-flask
-matplotlib.use('Agg')
-
-import functools
-import matplotlib.pyplot as plt
 import os
-import sys
 import time
 import unittest
-import uuid
-import yaml
 
-import ament_index_python
 import launch
 import launch_ros
 import launch_ros.actions
@@ -125,12 +114,10 @@ class TestCommandProfile(unittest.TestCase):
         smoothed_timestamps = []
 
         def received_input_data(msg):
-            # node.get_logger().warn("received input data {}".format(msg))
             input_velocities.append(msg.linear.x)
             input_timestamps.append(time.monotonic())
 
         def received_smoothed_data(msg):
-            # node.get_logger().warn("received smoothed data {}".format(msg))
             smoothed_velocities.append(msg.linear.x)
             smoothed_timestamps.append(time.monotonic())
 
@@ -153,13 +140,5 @@ class TestCommandProfile(unittest.TestCase):
             self.assertAlmostEqual(0.5, max(input_velocities))
             self.assertTrue(0.5 > max(smoothed_velocities))
             self.assertTrue(0.4 < max(smoothed_velocities))
-            # plot a graph for easy viz
-            plt.plot(input_timestamps, input_velocities, label="input")
-            plt.plot(smoothed_timestamps, smoothed_velocities, label="smooth")
-            plt.xlabel('time')
-            plt.ylabel('velocity')
-            plt.title("Raw Input vs Smoothed Velocities")
-            plt.legend()
-            plt.savefig('profiles.png')
             node.destroy_subscription(input_subscriber)
             node.destroy_subscription(smoothed_subscriber)

--- a/test/translational_command_profile.py
+++ b/test/translational_command_profile.py
@@ -97,25 +97,25 @@ class CommandProfile(object):
         cmd_vel.angular.y = 0.0
         cmd_vel.angular.z = 0.0
         odom = nav_msgs.Odometry()
-        odom.header.frame_id = "base_link"    
-        odom.pose.pose.position.x = 0.0    
-        odom.pose.pose.position.y = 0.0    
-        odom.pose.pose.position.z = 0.0    
-        odom.pose.pose.orientation.x = 0.0    
-        odom.pose.pose.orientation.y = 0.0    
-        odom.pose.pose.orientation.z = 0.0    
-        odom.pose.pose.orientation.w = 1.0    
-        odom.pose.covariance[0]  = 0.1    
-        odom.pose.covariance[7]  = 0.1    
-        odom.pose.covariance[35] = 0.2    
-        odom.pose.covariance[14] = 10.0    
-        odom.pose.covariance[21] = 10.0    
-        odom.pose.covariance[28] = 10.0    
-        odom.twist.twist.linear.x = 0.0    
-        odom.twist.twist.linear.y = 0.0    
-        odom.twist.twist.linear.z = 0.0    
-        odom.twist.twist.angular.x = 0.0    
-        odom.twist.twist.angular.y = 0.0    
+        odom.header.frame_id = "base_link"
+        odom.pose.pose.position.x = 0.0
+        odom.pose.pose.position.y = 0.0
+        odom.pose.pose.position.z = 0.0
+        odom.pose.pose.orientation.x = 0.0
+        odom.pose.pose.orientation.y = 0.0
+        odom.pose.pose.orientation.z = 0.0
+        odom.pose.pose.orientation.w = 1.0
+        odom.pose.covariance[0]  = 0.1
+        odom.pose.covariance[7]  = 0.1
+        odom.pose.covariance[35] = 0.2
+        odom.pose.covariance[14] = 10.0
+        odom.pose.covariance[21] = 10.0
+        odom.pose.covariance[28] = 10.0
+        odom.twist.twist.linear.x = 0.0
+        odom.twist.twist.linear.y = 0.0
+        odom.twist.twist.linear.z = 0.0
+        odom.twist.twist.angular.x = 0.0
+        odom.twist.twist.angular.y = 0.0
         odom.twist.twist.angular.z = 0.0
         return cmd_vel, odom
 
@@ -142,10 +142,10 @@ class ExecutionEngine(object):
             self.update_and_publish_odometry,
             10,
         )
-        self.odom_publisher = self.node.create_publisher(    
+        self.odom_publisher = self.node.create_publisher(
             msg_type=nav_msgs.Odometry,
             topic="~/odometry",
-            qos_profile=10,    
+            qos_profile=10,
         )
 
     def update_and_publish_odometry(self, msg):


### PR DESCRIPTION
The last commit has the explanation, but essentially we had to change the idea of how we do the test a bit.  I also did a bunch of cleanup of the test.  In my testing, this now works for both `ros2 test` and `colcon test`.

This should fix #10 