### PR TITLE
Cleanup parameter changes

### DIFF
--- a/include/velocity_smoother/velocity_smoother.hpp
+++ b/include/velocity_smoother/velocity_smoother.hpp
@@ -56,7 +56,7 @@ private:
     COMMANDS
   } feedback_;  /**< What source to use as feedback for smoothed velocity calculations */
 
-  double accel_lim_v_, decel_lim_v_;
+  double accel_lim_v_;
   double accel_lim_w_, decel_lim_w_;
 
   geometry_msgs::msg::Twist current_vel_;

--- a/include/velocity_smoother/velocity_smoother.hpp
+++ b/include/velocity_smoother/velocity_smoother.hpp
@@ -56,7 +56,6 @@ private:
     COMMANDS
   } feedback_;  /**< What source to use as feedback for smoothed velocity calculations */
 
-  bool quiet_;  /**< Quiet some warnings that are unavoidable because of velocity multiplexing. **/
   double speed_lim_v_, accel_lim_v_, decel_lim_v_;
   double speed_lim_w_, accel_lim_w_, decel_lim_w_;
 

--- a/include/velocity_smoother/velocity_smoother.hpp
+++ b/include/velocity_smoother/velocity_smoother.hpp
@@ -57,7 +57,7 @@ private:
   } feedback_;  /**< What source to use as feedback for smoothed velocity calculations */
 
   double accel_lim_v_, decel_lim_v_;
-  double speed_lim_w_, accel_lim_w_, decel_lim_w_;
+  double accel_lim_w_, decel_lim_w_;
 
   geometry_msgs::msg::Twist current_vel_;
   geometry_msgs::msg::Twist target_vel_;

--- a/include/velocity_smoother/velocity_smoother.hpp
+++ b/include/velocity_smoother/velocity_smoother.hpp
@@ -18,13 +18,12 @@
  *****************************************************************************/
 
 #include <algorithm>
-#include <string>
 #include <vector>
 
 #include <geometry_msgs/msg/twist.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 #include <rcl_interfaces/msg/set_parameters_result.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <nav_msgs/msg/odometry.hpp>
 
 /*****************************************************************************
 ** Namespaces

--- a/include/velocity_smoother/velocity_smoother.hpp
+++ b/include/velocity_smoother/velocity_smoother.hpp
@@ -56,7 +56,7 @@ private:
     COMMANDS
   } feedback_;  /**< What source to use as feedback for smoothed velocity calculations */
 
-  double speed_lim_v_, accel_lim_v_, decel_lim_v_;
+  double accel_lim_v_, decel_lim_v_;
   double speed_lim_w_, accel_lim_w_, decel_lim_w_;
 
   geometry_msgs::msg::Twist current_vel_;

--- a/include/velocity_smoother/velocity_smoother.hpp
+++ b/include/velocity_smoother/velocity_smoother.hpp
@@ -56,7 +56,6 @@ private:
     COMMANDS
   } feedback_;  /**< What source to use as feedback for smoothed velocity calculations */
 
-  double accel_lim_v_;
   double accel_lim_w_;
 
   geometry_msgs::msg::Twist current_vel_;

--- a/include/velocity_smoother/velocity_smoother.hpp
+++ b/include/velocity_smoother/velocity_smoother.hpp
@@ -57,7 +57,7 @@ private:
   } feedback_;  /**< What source to use as feedback for smoothed velocity calculations */
 
   double accel_lim_v_;
-  double accel_lim_w_, decel_lim_w_;
+  double accel_lim_w_;
 
   geometry_msgs::msg::Twist current_vel_;
   geometry_msgs::msg::Twist target_vel_;

--- a/include/velocity_smoother/velocity_smoother.hpp
+++ b/include/velocity_smoother/velocity_smoother.hpp
@@ -65,7 +65,6 @@ private:
   double last_cmd_vel_angular_z_{0.0};
 
   double period_;
-  double decel_factor_;
   bool input_active_;
   double cb_avg_time_;
   rclcpp::Time last_velocity_cb_time_;

--- a/src/velocity_smoother.cpp
+++ b/src/velocity_smoother.cpp
@@ -63,15 +63,7 @@ VelocitySmoother::VelocitySmoother(const rclcpp::NodeOptions & options)
 
   // Mandatory parameters
   this->declare_parameter("speed_lim_v", 0.8);
-
-  rclcpp::ParameterValue speed_w = this->declare_parameter(
-    "speed_lim_w",
-    rclcpp::ParameterValue(5.4)
-  );
-  if (speed_w.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE) {
-    throw std::runtime_error("speed_lim_w must be specified as a double");
-  }
-  speed_lim_w_ = speed_w.get<double>();
+  this->declare_parameter("speed_lim_w", 5.4);
 
   rclcpp::ParameterValue accel_v = this->declare_parameter(
     "accel_lim_v",
@@ -146,12 +138,13 @@ void VelocitySmoother::velocityCB(const geometry_msgs::msg::Twist::SharedPtr msg
 
   // Bound speed with the maximum values
   double speed_lim_v = get_parameter("speed_lim_v").as_double();
+  double speed_lim_w = get_parameter("speed_lim_w").as_double();
   target_vel_.linear.x =
     msg->linear.x > 0.0 ? std::min(msg->linear.x, speed_lim_v) : std::max(
     msg->linear.x, -speed_lim_v);
   target_vel_.angular.z =
-    msg->angular.z > 0.0 ? std::min(msg->angular.z, speed_lim_w_) : std::max(
-    msg->angular.z, -speed_lim_w_);
+    msg->angular.z > 0.0 ? std::min(msg->angular.z, speed_lim_w) : std::max(
+    msg->angular.z, -speed_lim_w);
 }
 
 void VelocitySmoother::odometryCB(const nav_msgs::msg::Odometry::SharedPtr msg)
@@ -328,14 +321,6 @@ rcl_interfaces::msg::SetParametersResult VelocitySmoother::parameterUpdate(
       result.successful = false;
       result.reason = "feedback cannot be changed on-the-fly";
       break;
-    } else if (parameter.get_name() == "speed_lim_w") {
-      if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE) {
-        result.successful = false;
-        result.reason = "speed_lim_w must be a double";
-        break;
-      }
-
-      speed_lim_w_ = parameter.get_value<double>();
     } else if (parameter.get_name() == "accel_lim_v") {
       if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE) {
         result.successful = false;

--- a/src/velocity_smoother.cpp
+++ b/src/velocity_smoother.cpp
@@ -49,7 +49,7 @@ VelocitySmoother::VelocitySmoother(const rclcpp::NodeOptions & options)
   pr_next_(0)
 {
   double frequency = this->declare_parameter("frequency", 20.0);
-  quiet_ = this->declare_parameter("quiet", false);
+  this->declare_parameter("quiet", false);
   decel_factor_ = this->declare_parameter("decel_factor", 1.0);
   int feedback = this->declare_parameter("feedback", static_cast<int>(NONE));
 
@@ -226,7 +226,7 @@ void VelocitySmoother::timerCB()
     // If the publisher has been inactive for a while, or if our current commanding differs a lot
     // from robot velocity feedback, we cannot trust the former; rely on robot's feedback instead
     // This might not work super well using the odometry if it has a high delay
-    if (!quiet_) {
+    if (!this->get_parameter("quiet").as_bool()) {
       // this condition can be unavoidable due to preemption of current velocity control on
       // velocity multiplexer so be quiet if we're instructed to do so
       RCLCPP_WARN(
@@ -322,14 +322,6 @@ rcl_interfaces::msg::SetParametersResult VelocitySmoother::parameterUpdate(
       result.successful = false;
       result.reason = "frequency cannot be changed on-the-fly";
       break;
-    } else if (parameter.get_name() == "quiet") {
-      if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
-        result.successful = false;
-        result.reason = "quiet must be a boolean";
-        break;
-      }
-
-      quiet_ = parameter.get_value<bool>();
     } else if (parameter.get_name() == "decel_factor") {
       if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE) {
         result.successful = false;

--- a/src/velocity_smoother.cpp
+++ b/src/velocity_smoother.cpp
@@ -374,10 +374,6 @@ rcl_interfaces::msg::SetParametersResult VelocitySmoother::parameterUpdate(
       }
 
       accel_lim_w_ = parameter.get_value<double>();
-    } else {
-      result.successful = false;
-      result.reason = "unknown parameter";
-      break;
     }
   }
 

--- a/src/velocity_smoother.cpp
+++ b/src/velocity_smoother.cpp
@@ -50,7 +50,7 @@ VelocitySmoother::VelocitySmoother(const rclcpp::NodeOptions & options)
 {
   double frequency = this->declare_parameter("frequency", 20.0);
   this->declare_parameter("quiet", false);
-  decel_factor_ = this->declare_parameter("decel_factor", 1.0);
+  this->declare_parameter("decel_factor", 1.0);
   int feedback = this->declare_parameter("feedback", static_cast<int>(NONE));
 
   if ((static_cast<int>(feedback) < NONE) || (static_cast<int>(feedback) > COMMANDS)) {
@@ -163,9 +163,11 @@ void VelocitySmoother::robotVelCB(const geometry_msgs::msg::Twist::SharedPtr msg
 
 void VelocitySmoother::timerCB()
 {
+  double decel_factor = this->get_parameter("decel_factor").as_double();
+
   // Deceleration can be more aggressive, if necessary
-  double decel_lim_v = decel_factor_ * accel_lim_v_;
-  double decel_lim_w = decel_factor_ * accel_lim_w_;
+  double decel_lim_v = decel_factor * accel_lim_v_;
+  double decel_lim_w = decel_factor * accel_lim_w_;
 
   if ((input_active_ == true) && (cb_avg_time_ > 0.0) &&
     ((this->get_clock()->now() - last_velocity_cb_time_).seconds() >
@@ -309,14 +311,6 @@ rcl_interfaces::msg::SetParametersResult VelocitySmoother::parameterUpdate(
       result.successful = false;
       result.reason = "frequency cannot be changed on-the-fly";
       break;
-    } else if (parameter.get_name() == "decel_factor") {
-      if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE) {
-        result.successful = false;
-        result.reason = "decel_factor must be a double";
-        break;
-      }
-
-      decel_factor_ = parameter.get_value<double>();
     } else if (parameter.get_name() == "feedback") {
       result.successful = false;
       result.reason = "feedback cannot be changed on-the-fly";

--- a/src/velocity_smoother.cpp
+++ b/src/velocity_smoother.cpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include <geometry_msgs/msg/twist.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 #include <rcl_interfaces/msg/set_parameters_result.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>


### PR DESCRIPTION
In particular, we don't need to check parameter types, as that is now done in the core for us.  Further, we really shouldn't be rejecting unknown parameters; it could be the case that other users of this node handle have parameters we don't know about.  Finally, we should not make internal changes to the node based on the parameter callback; instead, we can just go ahead and fetch the parameters from the database as we need it (this isn't quite as fast as referencing an internal variable, but it should be fast enough).

This makes the node much more compliant with modern ROS 2 practices, and removes a slew of code.