### PR TITLE
Don't install test artifacts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,18 +48,6 @@ install(DIRECTORY config launch
   DESTINATION share/${PROJECT_NAME}
 )
 
-install(
-  PROGRAMS
-    test/translational_command_profile.py
-  DESTINATION lib/${PROJECT_NAME}
-)
-
-install(
-  PROGRAMS
-    test/test_translational_smoothing.py
-  DESTINATION share/${PROJECT_NAME}/launch_test
-)
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/test/test_translational_smoothing.py
+++ b/test/test_translational_smoothing.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020 Daniel Stonier
@@ -10,6 +9,8 @@
 # Imports
 ##############################################################################
 
+import os
+import sys
 import time
 import unittest
 
@@ -38,9 +39,11 @@ matplotlib.use('Agg')  # Force matplotlib to not use an X-Windows backend
 
 
 def create_command_profile_node():
+    path_to_profile_dir = os.path.dirname(__file__)
+    path_to_command_profile = os.path.join(path_to_profile_dir, 'translational_command_profile.py')
     return launch_ros.actions.Node(
-        package='velocity_smoother',
-        executable='translational_command_profile.py',
+        executable=sys.executable,
+        arguments=[path_to_command_profile],
         name='commands',
         output='both',
         emulate_tty=True,

--- a/test/translational_command_profile.py
+++ b/test/translational_command_profile.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020 Daniel Stonier


### PR DESCRIPTION
This was a vestige from earlier when we couldn't figure out how to do this nicely.  We now have better examples, so don't install these test artifacts into the released product.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>