### PR TITLE
Rename the package to kobuki_velocity_smoother.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(velocity_smoother)
+project(kobuki_velocity_smoother)
 
 find_package(ament_cmake_ros REQUIRED)
 find_package(ecl_build REQUIRED)
@@ -31,7 +31,7 @@ target_link_libraries(velocity_smoother_node ${PROJECT_NAME})
 set_target_properties(velocity_smoother_node PROPERTIES OUTPUT_NAME velocity_smoother)
 
 rclcpp_components_register_nodes(${PROJECT_NAME}
-  "velocity_smoother::VelocitySmoother")
+  "kobuki_velocity_smoother::VelocitySmoother")
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION lib

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Velocity Smoother
+# Kobuki Velocity Smoother
 
 [[About](#about)][[Parameters](#parameters)][[Topics](#topics)][[Usage](#usage)][[Feedback](#feedback)]
 

--- a/config/velocity_smoother_params.yaml
+++ b/config/velocity_smoother_params.yaml
@@ -1,7 +1,7 @@
 # Example configuration:
 # - velocity limits are around a 10% above the physical limits
 # - acceleration limits are just low enough to avoid jerking
-velocity_smoother:
+kobuki_velocity_smoother:
   ros__parameters:
     # limits
     speed_lim_v: 0.8

--- a/include/kobuki_velocity_smoother/velocity_smoother.hpp
+++ b/include/kobuki_velocity_smoother/velocity_smoother.hpp
@@ -10,8 +10,8 @@
  ** Ifdefs
  *****************************************************************************/
 
-#ifndef VELOCITY_SMOOTHER__VELOCITY_SMOOTHER_HPP_
-#define VELOCITY_SMOOTHER__VELOCITY_SMOOTHER_HPP_
+#ifndef KOBUKI_VELOCITY_SMOOTHER__VELOCITY_SMOOTHER_HPP_
+#define KOBUKI_VELOCITY_SMOOTHER__VELOCITY_SMOOTHER_HPP_
 
 /*****************************************************************************
  ** Includes
@@ -29,7 +29,7 @@
 ** Namespaces
 *****************************************************************************/
 
-namespace velocity_smoother
+namespace kobuki_velocity_smoother
 {
 
 /*****************************************************************************
@@ -98,6 +98,6 @@ private:
   }
 };
 
-}  // namespace velocity_smoother
+}  // namespace kobuki_velocity_smoother
 
-#endif  // VELOCITY_SMOOTHER__VELOCITY_SMOOTHER_HPP_
+#endif  // KOBUKI_VELOCITY_SMOOTHER__VELOCITY_SMOOTHER_HPP_

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <package format="2">
-  <name>velocity_smoother</name>
+  <name>kobuki_velocity_smoother</name>
   <version>0.14.0</version>
   <description>
      Bound incoming velocity messages according to robot velocity and acceleration limits.
@@ -7,9 +7,9 @@
   <author>Jorge Santos Simon</author>
   <maintainer email="jihoonl@yujinrobot.com">Jihoon Lee</maintainer>
   <license>BSD</license>
-  <url type="website">https://index.ros.org/p/velocity_smoother/github-kobuki-base-velocity_smoother/</url>
-  <url type="repository">https://github.com/kobuki-base/velocity_smoother</url>
-  <url type="bugtracker">https://github.com/kobuki-base/velocity_smoother/issues</url>
+  <url type="website">https://index.ros.org/p/kobuki_velocity_smoother/github-kobuki-base-velocity_smoother/</url>
+  <url type="repository">https://github.com/kobuki-base/kobuki_velocity_smoother</url>
+  <url type="bugtracker">https://github.com/kobuki-base/kobuki_velocity_smoother/issues</url>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 

--- a/src/velocity_smoother.cpp
+++ b/src/velocity_smoother.cpp
@@ -26,7 +26,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 
-#include "velocity_smoother/velocity_smoother.hpp"
+#include "kobuki_velocity_smoother/velocity_smoother.hpp"
 
 /*****************************************************************************
  ** Preprocessing
@@ -38,7 +38,7 @@
 ** Namespaces
 *****************************************************************************/
 
-namespace velocity_smoother
+namespace kobuki_velocity_smoother
 {
 
 /*********************
@@ -46,7 +46,7 @@ namespace velocity_smoother
 **********************/
 
 VelocitySmoother::VelocitySmoother(const rclcpp::NodeOptions & options)
-: rclcpp::Node("velocity_smoother", options),
+: rclcpp::Node("kobuki_velocity_smoother", options),
   input_active_(false),
   last_velocity_cb_time_(this->get_clock()->now()),
   pr_next_(0)
@@ -311,6 +311,6 @@ rcl_interfaces::msg::SetParametersResult VelocitySmoother::parameterUpdate(
   return result;
 }
 
-}  // namespace velocity_smoother
+}  // namespace kobuki_velocity_smoother
 
-RCLCPP_COMPONENTS_REGISTER_NODE(velocity_smoother::VelocitySmoother)
+RCLCPP_COMPONENTS_REGISTER_NODE(kobuki_velocity_smoother::VelocitySmoother)

--- a/src/velocity_smoother_node.cpp
+++ b/src/velocity_smoother_node.cpp
@@ -14,13 +14,13 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "velocity_smoother/velocity_smoother.hpp"
+#include "kobuki_velocity_smoother/velocity_smoother.hpp"
 
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  rclcpp::spin(std::make_shared<velocity_smoother::VelocitySmoother>(rclcpp::NodeOptions()));
+  rclcpp::spin(std::make_shared<kobuki_velocity_smoother::VelocitySmoother>(rclcpp::NodeOptions()));
 
   rclcpp::shutdown();
 

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,7 @@
 
 ```bash
 INSTALL_DIR=<path_to_install_space>
-$ ros2 test ${INSTALL_DIR}/share/velocity_smoother/launch_tests/test_translational_smoothing.py
+$ ros2 test ${INSTALL_DIR}/share/kobuki_velocity_smoother/launch_tests/test_translational_smoothing.py
 ```
 
 To enable external interaction with it (e.g. via ros2cli), then use the `--disable-isolation` argument.

--- a/test/test_translational_smoothing.py
+++ b/test/test_translational_smoothing.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2020 Daniel Stonier
 #
 # License: BSD
-#   https://raw.githubusercontent.com/kobuki-base/velocity_smoother/license/LICENSE
+#   https://raw.githubusercontent.com/kobuki-base/kobuki_velocity_smoother/license/LICENSE
 #
 ##############################################################################
 # Imports
@@ -67,9 +67,9 @@ def create_velocity_smoother_node():
     parameters['decel_factor'] = 2.0
     parameters['feedback'] = 1  # 1 - ODOMETRY, 2 - COMMANDS (velocity_smoother.hpp)
     return launch_ros.actions.Node(
-        package='velocity_smoother',
+        package='kobuki_velocity_smoother',
         executable='velocity_smoother',
-        name='velocity_smoother',
+        name='kobuki_velocity_smoother',
         output='both',
         parameters=[parameters],
         remappings=[

--- a/test/translational_command_profile.py
+++ b/test/translational_command_profile.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2020 Daniel Stonier
 #
 # License: BSD
-#   https://raw.githubusercontent.com/kobuki-base/velocity_smoother/license/LICENSE
+#   https://raw.githubusercontent.com/kobuki-base/kobuki_velocity_smoother/license/LICENSE
 #
 ##############################################################################
 # Imports


### PR DESCRIPTION
This is to disambiguate it from other velocity smoother packages that exist in the ROS ecosystem.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@stonier FYI.  I just renamed the package and the namespace, while leaving the class name and executable names intact.  That should be enough to disambiguate it.