### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,18 +16,19 @@ include_directories(include)
 
 add_library(${PROJECT_NAME} SHARED src/velocity_smoother.cpp)
 target_link_libraries(${PROJECT_NAME} PUBLIC
-  "geometry_msgs"
-  "nav_msgs"
-  "rcl_interfaces"
-  "rclcpp"
-  "rclcpp_components"
+  ${geometry_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  ${rcl_interfaces_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
 )
 
 add_executable(velocity_smoother_node src/velocity_smoother_node.cpp)
 target_link_libraries(velocity_smoother_node PUBLIC
-  "rclcpp"
+  ${PROJECT_NAME}
+  rclcpp::rclcpp
 )
-target_link_libraries(velocity_smoother_node ${PROJECT_NAME})
 set_target_properties(velocity_smoother_node PROPERTIES OUTPUT_NAME velocity_smoother)
 
 rclcpp_components_register_nodes(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ ecl_enable_cxx_warnings()
 include_directories(include)
 
 add_library(${PROJECT_NAME} SHARED src/velocity_smoother.cpp)
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   "geometry_msgs"
   "nav_msgs"
   "rcl_interfaces"
@@ -24,7 +24,7 @@ ament_target_dependencies(${PROJECT_NAME}
 )
 
 add_executable(velocity_smoother_node src/velocity_smoother_node.cpp)
-ament_target_dependencies(velocity_smoother_node
+target_link_libraries(velocity_smoother_node PUBLIC
   "rclcpp"
 )
 target_link_libraries(velocity_smoother_node ${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   ${rcl_interfaces_TARGETS}
   rclcpp::rclcpp
   rclcpp_components::component
-  rclcpp_components::component_manager
 )
 
 add_executable(velocity_smoother_node src/velocity_smoother_node.cpp)


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
