### PR TITLE
Replace ament_target_dependencies with target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,17 +15,17 @@ ecl_enable_cxx_warnings()
 include_directories(include)
 
 add_library(${PROJECT_NAME} SHARED src/velocity_smoother.cpp)
-ament_target_dependencies(${PROJECT_NAME}
-  "geometry_msgs"
-  "nav_msgs"
-  "rcl_interfaces"
-  "rclcpp"
-  "rclcpp_components"
+target_link_libraries(${PROJECT_NAME}
+  ${geometry_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  ${rcl_interfaces_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_components::component
 )
 
 add_executable(velocity_smoother_node src/velocity_smoother_node.cpp)
-ament_target_dependencies(velocity_smoother_node
-  "rclcpp"
+target_link_libraries(velocity_smoother_node
+  rclcpp::rclcpp
 )
 target_link_libraries(velocity_smoother_node ${PROJECT_NAME})
 set_target_properties(velocity_smoother_node PROPERTIES OUTPUT_NAME velocity_smoother)


### PR DESCRIPTION
`ament_target_dependencies` is deprecated on `kilted` and removed in `rolling`,  It will require a new release on `rolling`.

Debs are broken https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__kobuki_velocity_smoother__ubuntu_noble_amd64__binary/